### PR TITLE
fix(ci): update release-please runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write # to create release commit (google-github-actions/release-please-action)
       pull-requests: write # to create release PR (google-github-actions/release-please-action)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release
@@ -19,8 +19,8 @@ jobs:
           package-name: "@bn3t/resume-ng"
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm install npm@latest -g


### PR DESCRIPTION
## Summary
- `ubuntu-20.04` was retired by GitHub Actions, causing all release-please runs to time out after 24h waiting for a runner that never comes
- Updates runner to `ubuntu-24.04` (consistent with all other workflows in this repo)
- Bumps `actions/checkout` v2 → v4 and `actions/setup-node` v1 → v4

## Test plan
- [ ] Verify the release-please workflow completes successfully on merge to main